### PR TITLE
fix view log

### DIFF
--- a/src/playground/command.ts
+++ b/src/playground/command.ts
@@ -153,7 +153,7 @@ export class PlaygroundCommand {
   }
 
   static async openInstanceLog(pid: string) {
-    const res = await shell.exec(`ps hw -p ${pid}`)
+    const res = await shell.exec(`ps w -p ${pid} | grep tiup`)
     console.log('ps result:', res)
     const m = res?.stdout.match(/log-file=(.+)\.log/)
     if (m) {
@@ -173,7 +173,7 @@ export class PlaygroundCommand {
   }
 
   static async followInstanceLog(tiup: TiUP, pid: string) {
-    const res = await shell.exec(`ps hw -p ${pid}`)
+    const res = await shell.exec(`ps w -p ${pid} | grep tiup`)
     console.log('ps result:', res)
     const m = res?.stdout.match(/log-file=(.+)\.log/)
     if (m) {

--- a/src/playground/command.ts
+++ b/src/playground/command.ts
@@ -153,7 +153,7 @@ export class PlaygroundCommand {
   }
 
   static async openInstanceLog(pid: string) {
-    const res = await shell.exec(`ps -p ${pid} | grep tiup`)
+    const res = await shell.exec(`ps hw -p ${pid}`)
     console.log('ps result:', res)
     const m = res?.stdout.match(/log-file=(.+)\.log/)
     if (m) {
@@ -173,7 +173,7 @@ export class PlaygroundCommand {
   }
 
   static async followInstanceLog(tiup: TiUP, pid: string) {
-    const res = await shell.exec(`ps -p ${pid} | grep tiup`)
+    const res = await shell.exec(`ps hw -p ${pid}`)
     console.log('ps result:', res)
     const m = res?.stdout.match(/log-file=(.+)\.log/)
     if (m) {


### PR DESCRIPTION
Signed-off-by: Zhenchi <zhongzc_arch@outlook.com>

Environment:

* Ubuntu 20.04

Current:

```sh
$ ps -p 7426
    PID TTY          TIME CMD
   7426 pts/1    00:00:19 pd-server
```

Patch:

```sh
$ ps hw -p 7426
   7426 pts/1    Sl     0:15 /home/zhongzc/.tiup/components/pd/v5.0.0-rc/pd-server --name=pd-0 --data-dir=/home/zhongzc/.tiup/data/SNpbuh6/pd-0/data --peer-urls=http://127.0.0.1:2380 --advertise-peer-urls=http://127.0.0.1:2380 --client-urls=http://127.0.0.1:2379 --advertise-client-urls=http://127.0.0.1:2379 --log-file=/home/zhongzc/.tiup/data/SNpbuh6/pd-0/pd.log --initial-cluster=pd-0=http://127.0.0.1:2380
```